### PR TITLE
[202205] [Mellanox] Add patch for reset cause

### DIFF
--- a/patch/0176-platform-mellanox-fix-reset_pwr_converter_fail-attri.patch
+++ b/patch/0176-platform-mellanox-fix-reset_pwr_converter_fail-attri.patch
@@ -1,0 +1,31 @@
+From 2e1b50d35889e78b05f507d60984d19fed53d07b Mon Sep 17 00:00:00 2001
+From: Michael Shych <michaelsh@nvidia.com>
+Date: Sun, 4 Sep 2022 10:41:45 +0300
+Subject: [PATCH backport 5.10 12/17] platform: mellanox: fix
+ reset_pwr_converter_fail attribute.
+
+Change incorrect reset_voltmon_upgrade_fail atitribute name to
+reset_pwr_converter_fail.
+
+Signed-off-by: Michael Shych <michaelsh@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index a580ab850..b9ea12fad 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -3414,7 +3414,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mode = 0444,
+ 	},
+ 	{
+-		.label = "reset_voltmon_upgrade_fail",
++		.label = "reset_pwr_converter_fail",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(0),
+ 		.mode = 0444,
+-- 
+2.20.1
+

--- a/patch/0177-Documentation-ABI-fix-description-of-fix-reset_pwr_c.patch
+++ b/patch/0177-Documentation-ABI-fix-description-of-fix-reset_pwr_c.patch
@@ -1,0 +1,38 @@
+From 5d52ea3e1f69d489b8cbda7a46faca511bdf7a3e Mon Sep 17 00:00:00 2001
+From: Michael Shych <michaelsh@nvidia.com>
+Date: Sun, 4 Sep 2022 10:46:01 +0300
+Subject: [PATCH 2/4] Documentation/ABI: fix description of fix
+ reset_pwr_converter_fail attribute.
+
+Change description of incorrect reset_voltmon_upgrade_fail atitribute
+name to reset_pwr_converter_fail.
+
+Signed-off-by: Michael Shych <michaelsh@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ Documentation/ABI/stable/sysfs-driver-mlxreg-io | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/ABI/stable/sysfs-driver-mlxreg-io b/Documentation/ABI/stable/sysfs-driver-mlxreg-io
+index 3914bb95e..06feaa986 100644
+--- a/Documentation/ABI/stable/sysfs-driver-mlxreg-io
++++ b/Documentation/ABI/stable/sysfs-driver-mlxreg-io
+@@ -103,13 +103,13 @@ Description:	These files show the system reset cause, as following: power
+ What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_comex_pwr_fail
+ What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_from_comex
+ What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_system
+-What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_voltmon_upgrade_fail
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_pwr_converter_fail
+ Date:		November 2018
+ KernelVersion:	5.0
+ Contact:	Vadim Pasternak <vadimpmellanox.com>
+ Description:	These files show the system reset cause, as following: ComEx
+ 		power fail, reset from ComEx, system platform reset, reset
+-		due to voltage monitor devices upgrade failure,
++		due to power converter devices failure,
+ 		Value 1 in file means this is reset cause, 0 - otherwise.
+ 		Only one bit could be 1 at the same time, representing only
+ 		the last reset cause.
+-- 
+2.14.1
+

--- a/patch/0178-platform-mellanox-Introduce-support-for-next-generat.patch
+++ b/patch/0178-platform-mellanox-Introduce-support-for-next-generat.patch
@@ -1,0 +1,300 @@
+From 6aabbd215bca0ed7d34d9f4ca6a7af1df80785bd Mon Sep 17 00:00:00 2001
+From: Michael Shych <michaelsh@nvidia.com>
+Date: Sun, 4 Sep 2022 14:03:58 +0300
+Subject: [PATCH backport 5.10 1/7] platform: mellanox: Introduce support for
+ next-generation 800GB/s ethernet switch.
+
+Introduce support for Nvidia next-generation 800GB/s ethernet switch - SN5600.
+SN5600 is 51.2 Tbps Ethernet switch based on Nvidia Spectrum-4 ASIC.
+It can provide up to 64x800Gb/s (ETH) full bidirectional bandwidth per port
+using PAM-4 modulations. The system supports 64 Belly to Belly  2x4 OSFP cages.
+The switch was designed to fit standard 2U racks.
+
+Features:
+- 64 OSFP ports support 800GbE - 10GbE speed.
+- Additional 25GbE - 1GbE service port on the front panel.
+- Air-cooled with 3 + 1 redundant fan units.
+- 1 + 1 redundant 3000W or 3600W PSUs.
+- System management board is based on Intel Coffee-lake CPU E-2276
+  with secure-boot support.
+
+Signed-off-by: Michael Shych <michaelsh@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 178 ++++++++++++++++++++++++++++
+ 1 file changed, 178 insertions(+)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 7a1746d6e..a7d51dc1c 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -109,6 +109,7 @@
+ #define MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET	0xaa
+ #define MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET	0xab
+ #define MLXPLAT_CPLD_LPC_REG_LC_PWR_ON		0xb2
++#define MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET	0xc2
+ #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET	0xc7
+ #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET	0xc8
+ #define MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET	0xc9
+@@ -243,6 +244,7 @@
+ #define MLXPLAT_CPLD_CH2_ETH_MODULAR		3
+ #define MLXPLAT_CPLD_CH3_ETH_MODULAR		43
+ #define MLXPLAT_CPLD_CH4_ETH_MODULAR		51
++#define MLXPLAT_CPLD_CH2_NG800			34
+
+ /* Number of LPC attached MUX platform devices */
+ #define MLXPLAT_CPLD_LPC_MUX_DEVS		4
+@@ -460,6 +462,37 @@ static struct i2c_mux_reg_platform_data mlxplat_modular_mux_data[] = {
+ 	},
+ };
+
++/* Platform channels for ng800 system family */
++static const int mlxplat_ng800_channels[] = {
++	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
++	18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
++};
++
++/* Platform ng800 mux data */
++static struct i2c_mux_reg_platform_data mlxplat_ng800_mux_data[] = {
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH1,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG1,
++		.reg_size = 1,
++		.idle_in_use = 1,
++		.values = mlxplat_ng800_channels,
++		.n_values = ARRAY_SIZE(mlxplat_ng800_channels),
++	},
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH2_NG800,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG2,
++		.reg_size = 1,
++		.idle_in_use = 1,
++		.values = mlxplat_msn21xx_channels,
++		.n_values = ARRAY_SIZE(mlxplat_msn21xx_channels),
++	},
++
++};
++
+ /* Platform hotplug devices */
+ static struct i2c_board_info mlxplat_mlxcpld_pwr[] = {
+ 	{
+@@ -479,6 +512,15 @@ static struct i2c_board_info mlxplat_mlxcpld_ext_pwr[] = {
+ 	},
+ };
+
++static struct i2c_board_info mlxplat_mlxcpld_pwr_ng800[] = {
++	{
++		I2C_BOARD_INFO("dps460", 0x59),
++	},
++	{
++		I2C_BOARD_INFO("dps460", 0x5a),
++	},
++};
++
+ static struct i2c_board_info mlxplat_mlxcpld_fan[] = {
+ 	{
+ 		I2C_BOARD_INFO("24c32", 0x50),
+@@ -558,6 +600,23 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_pwr_wc_items_data[] = {
+ 	},
+ };
+
++static struct mlxreg_core_data mlxplat_mlxcpld_default_pwr_ng800_items_data[] = {
++	{
++		.label = "pwr1",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = BIT(0),
++		.hpdev.brdinfo = &mlxplat_mlxcpld_pwr_ng800[0],
++		.hpdev.nr = MLXPLAT_CPLD_PSU_MSNXXXX_NR,
++	},
++	{
++		.label = "pwr2",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = BIT(1),
++		.hpdev.brdinfo = &mlxplat_mlxcpld_pwr_ng800[1],
++		.hpdev.nr = MLXPLAT_CPLD_PSU_MSNXXXX_NR,
++	},
++};
++
+ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_items_data[] = {
+ 	{
+ 		.label = "fan1",
+@@ -1181,6 +1240,47 @@ static struct mlxreg_core_item mlxplat_mlxcpld_ext_items[] = {
+ 	}
+ };
+
++static struct mlxreg_core_item mlxplat_mlxcpld_ng800_items[] = {
++	{
++		.data = mlxplat_mlxcpld_default_ng_psu_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = MLXPLAT_CPLD_PSU_EXT_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_ng_psu_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_default_pwr_ng800_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = MLXPLAT_CPLD_PWR_EXT_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_pwr_ng800_items_data),
++		.inversed = 0,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_default_ng_fan_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_FAN_OFFSET,
++		.mask = MLXPLAT_CPLD_FAN_NG_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_ng_fan_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_default_asic_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_asic_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++};
++
+ static
+ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ext_data = {
+ 	.items = mlxplat_mlxcpld_ext_items,
+@@ -1191,6 +1291,16 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ext_data = {
+ 	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2,
+ };
+
++static
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ng800_data = {
++	.items = mlxplat_mlxcpld_ng800_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_ng800_items),
++	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
++	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
++	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
++	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2,
++};
++
+ static struct mlxreg_core_data mlxplat_mlxcpld_modular_pwr_items_data[] = {
+ 	{
+ 		.label = "pwr1",
+@@ -2947,6 +3057,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(2),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "clk_brd_prog_en",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(1),
++		.mode = 0644,
++	},
+ 	{
+ 		.label = "reset_long_pb",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
+@@ -3049,6 +3165,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(6),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "reset_ac_ok_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(7),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "psu1_on",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
+@@ -3142,6 +3264,30 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(4),
+ 		.mode = 0644,
+ 	},
++	{
++		.label = "clk_brd1_boot_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "clk_brd2_boot_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
++		.label = "clk_brd_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0444,
++	},
++	{
++		.label = "asic_pg_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(7),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "config1",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET,
+@@ -3432,6 +3578,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
+ 		.bit = 5,
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "pwr_converter_prog_en",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
++		.mode = 0644,
++	},
+ 	{
+ 		.label = "vpd_wp",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
+@@ -4957,6 +5109,27 @@ static int __init mlxplat_dmi_modular_matched(const struct dmi_system_id *dmi)
+ 	return 1;
+ }
+
++static int __init mlxplat_dmi_ng800_matched(const struct dmi_system_id *dmi)
++{
++	int i;
++
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_ng800_mux_data);
++	mlxplat_mux_data = mlxplat_ng800_mux_data;
++	mlxplat_hotplug = &mlxplat_mlxcpld_ng800_data;
++	mlxplat_hotplug->deferred_nr =
++		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++	mlxplat_led = &mlxplat_default_ng_led_data;
++	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
++	mlxplat_fan = &mlxplat_default_fan_data;
++	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
++		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
++	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
++
++	return 1;
++}
++
+ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 	{
+ 		.callback = mlxplat_dmi_default_wc_matched,
+@@ -5019,6 +5192,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0011"),
+ 		},
+ 	},
++	{
++		.callback = mlxplat_dmi_ng800_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0013"),
++		},
++	},
+ 	{
+ 		.callback = mlxplat_dmi_chassis_blade_matched,
+ 		.matches = {

--- a/patch/series
+++ b/patch/series
@@ -129,15 +129,15 @@ kernel-compat-always-include-linux-compat.h-from-net-compat.patch
 0079-mlxsw-Add-ability-to-control-transceiver-module.patch
 0080-ethtool-Add-transceiver-module-extended-states.patch
 0081-platform-x86-mlx-platform-Add-support-for-multi.patch
-0082-mlxsw-core-Extend-external-cooling-device-whitelist-.patch  
-0083-platform_data-mlxreg-Add-field-for-notification-call.patch  
-0084-i2c-mlxcpld-Add-callback-to-notify-probing-completio.patch  
-0085-hwmon-powr1220-Upgrade-driver-to-support-hwmon-info-.patch  
-0086-hwmon-powr1220-Add-support-for-Lattice-s-POWR1014-po.patch  
-0087-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch  
-0088-dt-bindings-Add-description-for-EMC2305-for-RPM-base.patch  
-0089-platform-mellanox-Add-support-for-new-SN2201-system.patch   
-0090-Documentation-ABI-Add-new-attributes-for-mlxreg-io-s.patch 
+0082-mlxsw-core-Extend-external-cooling-device-whitelist-.patch
+0083-platform_data-mlxreg-Add-field-for-notification-call.patch
+0084-i2c-mlxcpld-Add-callback-to-notify-probing-completio.patch
+0085-hwmon-powr1220-Upgrade-driver-to-support-hwmon-info-.patch
+0086-hwmon-powr1220-Add-support-for-Lattice-s-POWR1014-po.patch
+0087-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
+0088-dt-bindings-Add-description-for-EMC2305-for-RPM-base.patch
+0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
+0090-Documentation-ABI-Add-new-attributes-for-mlxreg-io-s.patch
 0091-platform-x86-mlx-platform-Add-support-for-new-s.patch
 0092-platform-mellanox-mlxreg-lc-fix-error-code-in-m.patch
 0093-hwmon-mlxreg-fan-Extend-driver-to-support-multi.patch
@@ -160,7 +160,11 @@ kernel-compat-always-include-linux-compat.h-from-net-compat.patch
 0171-platform-mellanox-mlxreg-lc-Fix-cleanup-on-failure-a.patch
 0173-core-Add-support-for-OSFP-transceiver-modules.patch
 0175-hwmon-pmbus-Add-support-for-Infineon-Digital-Multi-p.patch
+0176-platform-mellanox-fix-reset_pwr_converter_fail-attri.patch
+0177-Documentation-ABI-fix-description-of-fix-reset_pwr_c.patch
+0178-platform-mellanox-Introduce-support-for-next-generat.patch
 0180-hwmon-pmbus-Fix-sensors-readouts-for-MPS-Multi-phase.patch
+
 
 # Cisco patches for 5.10 kernel
 cisco-mtd-part.patch


### PR DESCRIPTION
## Patch List
## New added patches:
- 0176-platform-mellanox-fix-reset_pwr_converter_fail-attri.patch : https://github.com/torvalds/linux/commit/488f0fca0db0
- 0177-Documentation-ABI-fix-description-of-fix-reset_pwr_c.patch : https://github.com/torvalds/linux/commit/e7210563432a
- 0178-platform-mellanox-Introduce-support-for-next-generat.patch : https://github.com/torvalds/linux/commit/fcf3790b9b63